### PR TITLE
RET/DIS: increment R(X) before restoring X and P

### DIFF
--- a/1802.cpp
+++ b/1802.cpp
@@ -252,9 +252,9 @@ int run(void)
     case 0:
     case 1: // ths same since we don't manage IE
       work = memread(reg[x]);
+      reg[x]++;
       x = work >> 4;
       p = work & 0xF;
-      reg[x]++;
       break;
     case 2:
       d = memread(reg[x]);


### PR DESCRIPTION
The 1802 documentation for RET and DIS isn't crystal clear, but R(X) must be incremented _before_ X is restored from the byte read from memory. Otherwise an interrupt handler executing DEC 2; SAV; ...; RET would trash the user's R(X).

The emma_02 and Run02 simulators also implement this behaviour.